### PR TITLE
Add websocket ack protocol

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -178,7 +178,12 @@ async function handleConnection(socket: WebSocket, request: http.IncomingMessage
     log.debug('new connection')
     unsubscribe = await broker.subscribe(uuid, async (data) => {
         log.debug('delivering payload')
-        await connection.send(data)
+        try {
+            await connection.send(data)
+        } catch (error) {
+            log.info(error, 'failed to deliver payload')
+            throw error
+        }
         log.info('payload delivered')
     })
     if (prematureClose) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,14 +1,14 @@
-import config from 'config'
-import cluster, {Worker} from 'cluster'
+import {URL} from 'url'
 import * as http from 'http'
 import * as os from 'os'
 import * as WebSocket from 'ws'
-import {URL} from 'url'
+import cluster, {Worker} from 'cluster'
+import config from 'config'
+import type Logger from 'bunyan'
 
 import logger from './logger'
-import version from './version'
 import setupBroker, {Broker, SendContext, Unsubscriber} from './broker'
-import type Logger from 'bunyan'
+import version from './version'
 
 let broker: Broker
 let requestSeq = 0

--- a/src/broker/broker.ts
+++ b/src/broker/broker.ts
@@ -23,8 +23,12 @@ export interface SendContext {
 /** Can be called to cancel a subscription. */
 export type Unsubscriber = () => void
 
-/** Function that is called when a subscription updates. */
-export type Updater = (payload: Buffer) => void
+/**
+ * Function that is called when a subscription updates.
+ * Should return a promise that resolves when the subscription has been updated.
+ * May throw to indicate that the update failed.
+ */
+export type Updater = (payload: Buffer) => Promise<void>
 
 export interface Broker {
     /** Send payload to channel and optionally wait for delivery.  */

--- a/src/broker/errors.ts
+++ b/src/broker/errors.ts
@@ -1,8 +1,8 @@
-/** Thrown when a send timeout occurs. */
-export class TimeoutError extends Error {
-    code = 'E_TIMEOUT'
-    constructor(timeout: number) {
-        super(`Timed out after ${timeout}ms`)
+/** Thrown when a delivery error or timeout occurs. */
+export class DeliveryError extends Error {
+    code = 'E_DELIVERY'
+    constructor(readonly reason: string) {
+        super(reason)
     }
 }
 

--- a/src/broker/index.ts
+++ b/src/broker/index.ts
@@ -35,3 +35,4 @@ async function setupBroker() {
 
 export default setupBroker
 export * from './broker'
+export * from './errors'


### PR DESCRIPTION
This allows websocket clients to opt into a simple protocol that requires delivery messages to be sent back over the socket before messages are removed from the queue in an attempt to reduce the amount of lost messages on poor connections
